### PR TITLE
feat(home): Setup Home Page Route & Layout

### DIFF
--- a/apps/web/deno.json
+++ b/apps/web/deno.json
@@ -22,10 +22,10 @@
     "preact/": "https://esm.sh/preact@10.19.6/",
     "@preact/signals": "https://esm.sh/@preact/signals@1.2.2",
     "@preact/signals-core": "https://esm.sh/@preact/signals-core@1.5.1",
-    "@mui/material": "https://esm.sh/@mui/material@5.15.11?alias=react:preact/compat&deps=preact@10.19.6",
-    "@mui/material/": "https://esm.sh/@mui/material@5.15.11&alias=react:preact/compat&deps=preact@10.19.6/",
-    "@mui/system": "https://esm.sh/@mui/system@5.15.11?alias=react:preact/compat&deps=preact@10.19.6",
-    "@emotion/react": "https://esm.sh/@emotion/react@11.11.3?alias=react:preact/compat&deps=preact@10.19.6",
+    "@mui/material": "https://esm.sh/@mui/material@5.15.20?alias=react:preact/compat&deps=preact@10.19.6",
+    "@mui/material/": "https://esm.sh/@mui/material@5.15.20&alias=react:preact/compat&deps=preact@10.19.6/",
+    "@mui/system": "https://esm.sh/@mui/system@5.15.20?alias=react:preact/compat&deps=preact@10.19.6",
+    "@emotion/react": "https://esm.sh/@emotion/react@11.11.4?alias=react:preact/compat&deps=preact@10.19.6",
     "@emotion/styled": "https://esm.sh/@emotion/styled@11.11.0?alias=react:preact/compat&deps=preact@10.19.6"
   },
   "compilerOptions": {

--- a/apps/web/deno.json
+++ b/apps/web/deno.json
@@ -21,7 +21,12 @@
     "preact": "https://esm.sh/preact@10.19.6",
     "preact/": "https://esm.sh/preact@10.19.6/",
     "@preact/signals": "https://esm.sh/@preact/signals@1.2.2",
-    "@preact/signals-core": "https://esm.sh/@preact/signals-core@1.5.1"
+    "@preact/signals-core": "https://esm.sh/@preact/signals-core@1.5.1",
+    "@mui/material": "https://esm.sh/@mui/material@5.15.11?alias=react:preact/compat&deps=preact@10.19.6",
+    "@mui/material/": "https://esm.sh/@mui/material@5.15.11&alias=react:preact/compat&deps=preact@10.19.6/",
+    "@mui/system": "https://esm.sh/@mui/system@5.15.11?alias=react:preact/compat&deps=preact@10.19.6",
+    "@emotion/react": "https://esm.sh/@emotion/react@11.11.3?alias=react:preact/compat&deps=preact@10.19.6",
+    "@emotion/styled": "https://esm.sh/@emotion/styled@11.11.0?alias=react:preact/compat&deps=preact@10.19.6"
   },
   "compilerOptions": {
     "jsx": "react-jsx",

--- a/apps/web/routes/home.tsx
+++ b/apps/web/routes/home.tsx
@@ -1,27 +1,33 @@
 import { Handlers } from "$fresh/server.ts";
 import { Box, Button, Container, Stack, Typography } from "@mui/material";
 
+/**
+ * Home page handler with SSR auth check.
+ * Redirects to /login if no auth cookie is present.
+ * TODO: Cookie name and validation will be finalized in Issue #105.
+ */
 export const handler: Handlers = {
   GET(req, ctx) {
     const cookies = req.headers.get("cookie");
-    // TODO: Verify the correct cookie name with the backend team.
-    // Assuming 'auth_token' or similar for now.
-    // If no cookie is present at all, definitely redirect.
-    if (!cookies) {
+
+    // Check for auth_token cookie (name may change based on Issue #105)
+    const hasAuthToken = cookies?.split(";")
+      .some((c) => c.trim().startsWith("auth_token="));
+
+    if (!hasAuthToken) {
       return new Response("", {
         status: 307,
         headers: { Location: "/login" },
       });
     }
 
-    // TODO: Validate token validity if possible or rely on API calls to fail.
+    // TODO: Validate token validity with backend (Issue #105)
 
     return ctx.render();
   },
 };
 
 export default function Home() {
-  // @ts-ignore: MUI types with Preact/Fresh
   return (
     <Container maxWidth="md">
       <Box sx={{ my: 4 }}>
@@ -31,7 +37,7 @@ export default function Home() {
           alignItems="center"
           mb={4}
         >
-          <Typography variant="h4" component="h1" gutterBottom>
+          <Typography variant="h4" gutterBottom>
             Nikki Home
           </Typography>
           <Button variant="contained" color="primary" href="/new">
@@ -41,7 +47,7 @@ export default function Home() {
         <Typography variant="body1">
           Welcome to your diary dashboard.
         </Typography>
-        {/* NikkiList will go here */}
+        {/* NikkiList will go here (Issue #102) */}
       </Box>
     </Container>
   );

--- a/apps/web/routes/home.tsx
+++ b/apps/web/routes/home.tsx
@@ -1,0 +1,48 @@
+import { Handlers } from "$fresh/server.ts";
+import { Box, Button, Container, Stack, Typography } from "@mui/material";
+
+export const handler: Handlers = {
+  GET(req, ctx) {
+    const cookies = req.headers.get("cookie");
+    // TODO: Verify the correct cookie name with the backend team.
+    // Assuming 'auth_token' or similar for now.
+    // If no cookie is present at all, definitely redirect.
+    if (!cookies) {
+      return new Response("", {
+        status: 307,
+        headers: { Location: "/login" },
+      });
+    }
+
+    // TODO: Validate token validity if possible or rely on API calls to fail.
+
+    return ctx.render();
+  },
+};
+
+export default function Home() {
+  // @ts-ignore: MUI types with Preact/Fresh
+  return (
+    <Container maxWidth="md">
+      <Box sx={{ my: 4 }}>
+        <Stack
+          direction="row"
+          justifyContent="space-between"
+          alignItems="center"
+          mb={4}
+        >
+          <Typography variant="h4" component="h1" gutterBottom>
+            Nikki Home
+          </Typography>
+          <Button variant="contained" color="primary" href="/new">
+            New Entry
+          </Button>
+        </Stack>
+        <Typography variant="body1">
+          Welcome to your diary dashboard.
+        </Typography>
+        {/* NikkiList will go here */}
+      </Box>
+    </Container>
+  );
+}


### PR DESCRIPTION
## Summary
Implements the basic route and layout for /home as outlined in Issue #101.

## Changes
- Added MUI dependencies (@mui/material, @emotion/react, @emotion/styled) to deno.json
- Created routes/home.tsx with:
  - SSR auth check (redirects to /login if no cookie present)
  - Basic layout using MUI Container, Box, Stack, Typography, Button
  - Placeholder for NikkiList component (to be implemented in #102)

## Testing
- [x] Code passes deno task check (fmt + lint)
- [ ] Manual verification pending (requires backend auth implementation)

## Related Issues
Closes #101
Part of home page implementation series (#101, #102, #103)

## Next Steps
- Issue #102: Implement NikkiCard & NikkiList Components
- Issue #103: Integrate API & State Management