### PR TITLE
Add HttpOnly session cookie auth

### DIFF
--- a/apps/web/routes/__tests__/home.test.ts
+++ b/apps/web/routes/__tests__/home.test.ts
@@ -1,0 +1,78 @@
+import { assertEquals } from "std/testing/asserts";
+import { FakeTime } from "https://deno.land/std@0.224.0/testing/time.ts";
+import type { HandlerContext } from "$fresh/server.ts";
+import { handler } from "../home.tsx";
+import {
+  createSession,
+  deleteSession,
+  SESSION_COOKIE_NAME,
+  SESSION_MAX_AGE_SECONDS,
+} from "../../utils/session.ts";
+
+function createHandlerContext(): HandlerContext {
+  return {
+    params: {},
+    render: () => Promise.resolve(new Response("home", { status: 200 })),
+    state: {},
+  } as HandlerContext;
+}
+
+function createRequest(cookieHeader?: string) {
+  const headers = cookieHeader ? { cookie: cookieHeader } : undefined;
+  return new Request("http://localhost/home", { headers });
+}
+
+Deno.test("GET /home renders when session cookie is valid", async () => {
+  const token = createSession("tester");
+
+  try {
+    const response = await handler.GET!(
+      createRequest(`${SESSION_COOKIE_NAME}=${token}`),
+      createHandlerContext(),
+    );
+
+    assertEquals(response.status, 200);
+  } finally {
+    deleteSession(token);
+  }
+});
+
+Deno.test("GET /home redirects to login when cookie is missing", async () => {
+  const response = await handler.GET!(
+    createRequest(),
+    createHandlerContext(),
+  );
+
+  assertEquals(response.status, 302);
+  assertEquals(response.headers.get("location"), "/");
+});
+
+Deno.test("GET /home redirects to login when cookie is invalid", async () => {
+  const response = await handler.GET!(
+    createRequest(`${SESSION_COOKIE_NAME}=invalid-token`),
+    createHandlerContext(),
+  );
+
+  assertEquals(response.status, 302);
+  assertEquals(response.headers.get("location"), "/");
+});
+
+Deno.test("GET /home redirects when session is expired", async () => {
+  const time = new FakeTime();
+  const token = createSession("expired-user");
+
+  try {
+    time.tick((SESSION_MAX_AGE_SECONDS * 1000) + 1);
+
+    const response = await handler.GET!(
+      createRequest(`${SESSION_COOKIE_NAME}=${token}`),
+      createHandlerContext(),
+    );
+
+    assertEquals(response.status, 302);
+    assertEquals(response.headers.get("location"), "/");
+  } finally {
+    time.restore();
+    deleteSession(token);
+  }
+});

--- a/apps/web/routes/_middleware.ts
+++ b/apps/web/routes/_middleware.ts
@@ -1,5 +1,9 @@
 import { MiddlewareHandlerContext } from "$fresh/server.ts";
-import { getUserFromRequest } from "../utils/auth_cookie.ts";
+import { getCookies } from "std/http/cookie";
+import {
+  SESSION_COOKIE_NAME,
+  validateSession,
+} from "../utils/session.ts";
 
 const PUBLIC_PATHS = ["/", "/login", "/api/login"];
 const PUBLIC_PREFIXES = ["/static", "/_frsh", "/favicon.ico", "/manifest.json"];
@@ -20,7 +24,11 @@ export async function handler(
   const url = new URL(req.url);
   const pathname = url.pathname;
 
-  const user = await getUserFromRequest(req);
+  const cookies = getCookies(req.headers);
+  const token = cookies[SESSION_COOKIE_NAME];
+  const session = token ? validateSession(token) : null;
+  const user = session ? { user_id: session.userId } : null;
+
   if (user) {
     ctx.state.user = user;
   }

--- a/apps/web/routes/api/__tests__/login.test.ts
+++ b/apps/web/routes/api/__tests__/login.test.ts
@@ -1,10 +1,17 @@
 import {
+  assert,
   assertEquals,
   assertObjectMatch,
-} from "https://deno.land/std@0.224.0/testing/asserts.ts";
-import { join } from "https://deno.land/std@0.224.0/path/mod.ts";
-import { handler } from "../login.ts";
+} from "std/testing/asserts";
+import { getSetCookies } from "std/http/cookie";
+import { join } from "std/path";
 import type { HandlerContext } from "$fresh/server.ts";
+import { handler } from "../login.ts";
+import {
+  deleteSession,
+  SESSION_COOKIE_NAME,
+  SESSION_MAX_AGE_SECONDS,
+} from "../../../utils/session.ts";
 import { createSQLiteClient } from "../../../../../packages/infrastructure/db/sqlite.ts";
 
 type LoginBody = {
@@ -84,6 +91,22 @@ Deno.test("POST /api/login returns 200 and user on valid credentials", async () 
       user_id: "tester",
       user_name: "Tester",
     });
+
+    const cookies = getSetCookies(response.headers);
+    const sessionCookie = cookies.find((cookie) =>
+      cookie.name === SESSION_COOKIE_NAME
+    );
+
+    assert(sessionCookie);
+    assert(sessionCookie!.value.length > 0);
+    assertEquals(sessionCookie!.httpOnly, true);
+    assertEquals(sessionCookie!.sameSite, "Lax");
+    assertEquals(sessionCookie!.path, "/");
+    assertEquals(sessionCookie!.maxAge, SESSION_MAX_AGE_SECONDS);
+
+    if (sessionCookie?.value) {
+      deleteSession(sessionCookie.value);
+    }
   } finally {
     if (originalDbPath === undefined) {
       Deno.env.delete("DB_PATH");
@@ -111,6 +134,7 @@ Deno.test("POST /api/login returns 400 for invalid credentials", async () => {
     assertObjectMatch(body as Record<string, unknown>, {
       error: "User not found",
     });
+    assertEquals(getSetCookies(response.headers).length, 0);
   } finally {
     if (originalDbPath === undefined) {
       Deno.env.delete("DB_PATH");
@@ -132,4 +156,5 @@ Deno.test("POST /api/login returns 400 when request body is missing", async () =
   assertObjectMatch(body as Record<string, unknown>, {
     error: "user_id と password は必須です。",
   });
+  assertEquals(getSetCookies(response.headers).length, 0);
 });

--- a/apps/web/utils/__tests__/session.test.ts
+++ b/apps/web/utils/__tests__/session.test.ts
@@ -1,0 +1,55 @@
+import {
+  assert,
+  assertEquals,
+  assertNotEquals,
+  assertObjectMatch,
+} from "std/testing/asserts";
+import { FakeTime } from "https://deno.land/std@0.224.0/testing/time.ts";
+import {
+  createSession,
+  deleteSession,
+  generateSessionToken,
+  SESSION_MAX_AGE_SECONDS,
+  validateSession,
+} from "../session.ts";
+
+Deno.test("generateSessionToken returns unique values", () => {
+  const tokenA = generateSessionToken();
+  const tokenB = generateSessionToken();
+
+  assertNotEquals(tokenA, tokenB);
+});
+
+Deno.test("createSession and validateSession return the session user", () => {
+  const token = createSession("tester");
+
+  try {
+    const session = validateSession(token);
+    assert(session);
+    assertObjectMatch(session, { userId: "tester" });
+  } finally {
+    deleteSession(token);
+  }
+});
+
+Deno.test("validateSession rejects expired sessions", () => {
+  const time = new FakeTime();
+  const token = createSession("expired-user");
+
+  try {
+    time.tick((SESSION_MAX_AGE_SECONDS * 1000) + 1);
+    const session = validateSession(token);
+    assertEquals(session, null);
+  } finally {
+    time.restore();
+    deleteSession(token);
+  }
+});
+
+Deno.test("deleteSession removes session", () => {
+  const token = createSession("deleter");
+
+  deleteSession(token);
+  const session = validateSession(token);
+  assertEquals(session, null);
+});

--- a/apps/web/utils/session.ts
+++ b/apps/web/utils/session.ts
@@ -1,0 +1,41 @@
+export const SESSION_COOKIE_NAME = "nikki_session";
+export const SESSION_MAX_AGE_SECONDS = 60 * 60 * 24; // 1 day
+const SESSION_TTL_MS = SESSION_MAX_AGE_SECONDS * 1000;
+
+type SessionRecord = {
+  userId: string;
+  expiresAt: number;
+};
+
+const sessions = new Map<string, SessionRecord>();
+
+export function generateSessionToken(): string {
+  return crypto.randomUUID();
+}
+
+export function createSession(userId: string): string {
+  const token = generateSessionToken();
+  sessions.set(token, {
+    userId,
+    expiresAt: Date.now() + SESSION_TTL_MS,
+  });
+  return token;
+}
+
+export function validateSession(
+  token: string,
+): { userId: string } | null {
+  const session = sessions.get(token);
+  if (!session) return null;
+
+  if (session.expiresAt <= Date.now()) {
+    sessions.delete(token);
+    return null;
+  }
+
+  return { userId: session.userId };
+}
+
+export function deleteSession(token: string) {
+  sessions.delete(token);
+}


### PR DESCRIPTION
## Summary
- add in-memory session utility and issue HttpOnly SameSite=Lax nikki_session cookie on login
- guard /home via session validation and populate user state
- add unit tests for session, login cookie issuance, and home route redirects

## Testing
- deno test (fails on Windows: Deno panic 'Unexpected client pipe failure')